### PR TITLE
Fix dashboard navigation bugs

### DIFF
--- a/develop-plugin/scripts/dashboard/app.py
+++ b/develop-plugin/scripts/dashboard/app.py
@@ -269,7 +269,7 @@ class SwarmDashboard(App):
     def action_open_pr(self) -> None:
         """Open the selected workbranch's PR in the browser."""
         wb = self._get_selected_workbranch()
-        if wb and wb.pr_url:
+        if wb and wb.pr_url and wb.pr_url.startswith(("https://", "http://")):
             webbrowser.open(wb.pr_url)
             self.notify(f"Opening PR: {wb.pr_url}", timeout=2)
         else:


### PR DESCRIPTION
## Summary
- Add URL scheme validation (`https://` or `http://`) before calling `webbrowser.open()` on PR URLs, preventing potential issues with malformed or arbitrary URL schemes.

**Note:** The `_selected_name` method and `_update_widgets` detail panel access were already using safe `.get()` patterns in the current codebase, so no changes were needed for those.

## Test plan
- [ ] Verify that clicking "Open PR" with a valid `https://` PR URL opens the browser correctly
- [ ] Verify that a workbranch with a malformed `pr_url` (e.g., no scheme) does not trigger `webbrowser.open`
- [ ] Verify navigation up/down still works and displays the correct workbranch name

🤖 Generated with [Claude Code](https://claude.com/claude-code)