### PR TITLE
Clean up dashboard UI: remove dead code and fix labels

### DIFF
--- a/develop-plugin/scripts/dashboard/app.py
+++ b/develop-plugin/scripts/dashboard/app.py
@@ -9,8 +9,6 @@ from pathlib import Path
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.widgets import Header, Footer, Static
-from rich.text import Text
-from rich.panel import Panel
 
 from .models import SwarmState
 from .state import SwarmStateReader
@@ -21,54 +19,6 @@ from .widgets.detail_panel import DetailPanel
 
 
 CSS_PATH = Path(__file__).parent / "css" / "dashboard.tcss"
-
-
-class LearningsModal(Static):
-    """Modal showing wave-learnings.md content."""
-
-    def __init__(self, content: str = "", **kwargs) -> None:
-        super().__init__(**kwargs)
-        self._content = content
-
-    def render(self):
-        return Panel(
-            Text(self._content or "No learnings found.", style="white"),
-            title="Wave Learnings",
-            border_style="blue",
-            padding=(1, 2),
-        )
-
-
-class ContractModal(Static):
-    """Modal showing project-contract.md content."""
-
-    def __init__(self, content: str = "", **kwargs) -> None:
-        super().__init__(**kwargs)
-        self._content = content
-
-    def render(self):
-        return Panel(
-            Text(self._content or "No contract found.", style="white"),
-            title="Project Contract",
-            border_style="cyan",
-            padding=(1, 2),
-        )
-
-
-class ErrorModal(Static):
-    """Modal showing error details for a failed workbranch."""
-
-    def __init__(self, content: str = "", **kwargs) -> None:
-        super().__init__(**kwargs)
-        self._content = content
-
-    def render(self):
-        return Panel(
-            Text(self._content or "No error details.", style="red"),
-            title="Error Detail",
-            border_style="red",
-            padding=(1, 2),
-        )
 
 
 class SwarmDashboard(App):

--- a/develop-plugin/scripts/dashboard/widgets/merge_queue.py
+++ b/develop-plugin/scripts/dashboard/widgets/merge_queue.py
@@ -6,7 +6,7 @@ from textual.widgets import Static
 from rich.text import Text
 from rich.panel import Panel
 
-from ..models import SwarmState, WaveState
+from ..models import SwarmState
 
 
 class MergeQueueBar(Static):
@@ -55,7 +55,7 @@ class MergeQueueBar(Static):
             in_progress_count = sum(1 for wb in wbs.values() if wb.status == "in-progress")
 
             if merged_count > 0 and done_count < total:
-                # Some merged, some still going — queue is active
+                # Some merged, not all resolved (merged+failed < total) — queue is active
                 next_to_merge = None
                 for slug in current_wave.merge_order:
                     wb = wbs.get(slug)
@@ -66,7 +66,7 @@ class MergeQueueBar(Static):
                 if next_to_merge:
                     t.append("active", style="yellow bold")
                     t.append("  \u2502  ", style="dim")
-                    t.append(f"Merging: ", style="bold")
+                    t.append("Next: ", style="bold")
                     t.append(next_to_merge.name, style="yellow")
                     if next_to_merge.pr_number:
                         t.append(f" (PR {next_to_merge.pr_number})", style="cyan")


### PR DESCRIPTION
## Summary
- Remove three unused modal classes (`LearningsModal`, `ContractModal`, `ErrorModal`) from `app.py` — they are never instantiated; the actions use `self.notify()` instead
- Remove unused `rich.text.Text` and `rich.panel.Panel` imports from `app.py` (only used by the dead modal classes)
- Remove unused `WaveState` import from `merge_queue.py`
- Fix `"Merging:"` label to `"Next:"` in the merge queue bar — the code finds the next workbranch to be merged, it is not actively being merged
- Fix inaccurate comment to reflect that the condition also counts failed workbranches (`merged+failed < total`)

## Test plan
- [ ] Run the dashboard and verify the merge queue bar displays "Next:" instead of "Merging:" for pending workbranches
- [ ] Verify no import errors on startup after removing dead imports and classes
- [ ] Confirm all existing keybindings (l, c, e) still work via `self.notify()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)