### PR TITLE
Fix #19: Worktree guardrails for swarm agents

### DIFF
--- a/develop-plugin/commands/swarm.md
+++ b/develop-plugin/commands/swarm.md
@@ -301,6 +301,33 @@ Print wave start banner:
 ═══════════════════════════════════════════
 ```
 
+### 10c.1 Pre-wave worktree checks
+
+Before dispatching any agent for this wave, verify the environment:
+
+1. Confirm the orchestrator is NOT inside a worktree:
+```bash
+if [[ "$PWD" == *".claude/worktrees"* ]]; then
+  echo "ERROR: Orchestrator is inside a worktree at $PWD — aborting wave"
+  # Halt the swarm
+fi
+```
+
+2. Prune stale worktrees:
+```bash
+git worktree prune
+```
+
+3. Check for rogue settings files in worktree directories:
+```bash
+ROGUE=$(find .claude/worktrees -name "settings.local.json" 2>/dev/null)
+if [[ -n "$ROGUE" ]]; then
+  echo "WARNING: Rogue settings files found in worktrees, removing:"
+  echo "$ROGUE"
+  rm -f $ROGUE
+fi
+```
+
 ### 10d. Dispatch auto-dev agents (parallel)
 
 For each workbranch in the wave's set, invoke one Agent tool call. All agents are dispatched concurrently — do not wait for agent N to finish before dispatching agent N+1.
@@ -316,6 +343,7 @@ Agent tool parameters:
 
 ```
 tools: ["Edit", "Write", "Glob", "Grep", "Read", "NotebookEdit", "Bash"]
+isolation: "worktree"
 ```
 
 Prompt template (substitute angle-bracket placeholders with actual values):
@@ -437,6 +465,27 @@ or:
   ✗ <workbranch-name> — failed: <error summary>
 ```
 
+### 10f.1 Post-agent worktree cleanup
+
+After confirming each agent's completion (success or failure):
+
+- Run `git worktree prune` to clean up any auto-removed worktrees
+- For failed agents: if the worktree directory still exists, remove it with `git worktree remove --force <path>`
+- Delete the agent's feature branch if the agent failed and no PR was created: `git branch -D <branch-name> 2>/dev/null`
+
+```bash
+git worktree prune
+for each failed agent with worktree path AGENT_WORKTREE and branch AGENT_BRANCH:
+  if [ -d "$AGENT_WORKTREE" ]; then
+    git worktree remove --force "$AGENT_WORKTREE"
+  fi
+  # Only delete branch if no PR was created
+  if [ -z "$AGENT_PR_NUMBER" ]; then
+    git branch -D "$AGENT_BRANCH" 2>/dev/null
+  fi
+done
+```
+
 ### 10g. Sequential merge queue
 
 Verify working directory before proceeding:
@@ -519,6 +568,23 @@ git push origin "swarm/${PLAN_SLUG}/post-wave-${N}"
 ```
 
 Append the tag to the state file's `tags` array.
+
+### 10h.1 Post-wave worktree cleanup
+
+Run post-wave worktree cleanup:
+```bash
+git worktree prune
+```
+
+Verify no orphaned worktree directories remain:
+```bash
+if [ -d ".claude/worktrees" ]; then
+  ORPHANS=$(find .claude/worktrees -maxdepth 1 -type d ! -name worktrees 2>/dev/null | wc -l)
+  if [ "$ORPHANS" -gt 0 ]; then
+    echo "WARNING: $ORPHANS orphaned worktree directories remain in .claude/worktrees/"
+  fi
+fi
+```
 
 ### 10i. Run wave-transition agent
 

--- a/develop-plugin/commands/swarm.md
+++ b/develop-plugin/commands/swarm.md
@@ -324,7 +324,7 @@ ROGUE=$(find .claude/worktrees -name "settings.local.json" 2>/dev/null)
 if [[ -n "$ROGUE" ]]; then
   echo "WARNING: Rogue settings files found in worktrees, removing:"
   echo "$ROGUE"
-  rm -f $ROGUE
+  echo "$ROGUE" | while IFS= read -r f; do rm -f "$f"; done
 fi
 ```
 
@@ -345,6 +345,8 @@ Agent tool parameters:
 tools: ["Edit", "Write", "Glob", "Grep", "Read", "NotebookEdit", "Bash"]
 isolation: "worktree"
 ```
+
+The `isolation` parameter ensures each agent runs in a system-managed worktree — agents must never create worktrees manually.
 
 Prompt template (substitute angle-bracket placeholders with actual values):
 
@@ -475,15 +477,17 @@ After confirming each agent's completion (success or failure):
 
 ```bash
 git worktree prune
-for each failed agent with worktree path AGENT_WORKTREE and branch AGENT_BRANCH:
-  if [ -d "$AGENT_WORKTREE" ]; then
-    git worktree remove --force "$AGENT_WORKTREE"
-  fi
-  # Only delete branch if no PR was created
-  if [ -z "$AGENT_PR_NUMBER" ]; then
-    git branch -D "$AGENT_BRANCH" 2>/dev/null
-  fi
-done
+```
+
+For each failed agent (with worktree path `AGENT_WORKTREE`, branch `AGENT_BRANCH`, and PR number `AGENT_PR_NUMBER`), run:
+
+```bash
+if [ -d "$AGENT_WORKTREE" ]; then
+  git worktree remove --force "$AGENT_WORKTREE"
+fi
+if [ -z "$AGENT_PR_NUMBER" ]; then
+  git branch -D "$AGENT_BRANCH" 2>/dev/null
+fi
 ```
 
 ### 10g. Sequential merge queue
@@ -579,7 +583,7 @@ git worktree prune
 Verify no orphaned worktree directories remain:
 ```bash
 if [ -d ".claude/worktrees" ]; then
-  ORPHANS=$(find .claude/worktrees -maxdepth 1 -type d ! -name worktrees 2>/dev/null | wc -l)
+  ORPHANS=$(find .claude/worktrees -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l)
   if [ "$ORPHANS" -gt 0 ]; then
     echo "WARNING: $ORPHANS orphaned worktree directories remain in .claude/worktrees/"
   fi

--- a/develop-plugin/skills/autonomous-feature-developer/SKILL.md
+++ b/develop-plugin/skills/autonomous-feature-developer/SKILL.md
@@ -113,6 +113,21 @@ If the bug report write fails, continue — it must never block the pipeline.
 
 ---
 
+## Worktree Rules
+
+You are running inside an isolated worktree managed by the swarm system. These rules are mandatory:
+
+- **Do NOT** run `git worktree add` — you are already in a worktree
+- **Do NOT** create directories named `.worktrees/` or `worktrees/`
+- **Do NOT** write to or create `.claude/settings.local.json` — this overrides permissions for all agents
+- **Do NOT** create nested worktrees (worktree inside a worktree)
+- If `.git` is a file (not a directory), you are in a worktree — work from your current directory
+- All your work happens in the current working directory. Do not attempt to `cd` to the project root or another worktree.
+
+If you detect that you are about to write `.claude/settings.local.json`, STOP. This file controls permissions for the entire session and must not be modified by feature agents.
+
+---
+
 ## Phase 0 — Setup
 
 Run the setup script with the feature request as the argument. An alternate context file path may be passed as a second argument — omit it to use the default (`docs/project-context.md`):


### PR DESCRIPTION
## Summary

Fixes #19. Adds worktree guardrails to prevent rogue worktrees, nested worktrees, rogue `.claude/settings.local.json` files, and orphaned branches during swarm runs.

### Changes

1. **Enforce `isolation: "worktree"`** on Agent tool dispatches in step 10d of `swarm.md`
2. **Pre-wave worktree checks** (step 10c.1): verify orchestrator is not inside a worktree, prune stale worktrees, remove rogue settings files from worktree directories
3. **Post-agent cleanup** (step 10f.1): prune worktrees after agent completion, force-remove worktree directories for failed agents, delete orphaned branches when no PR was created
4. **Post-wave cleanup** (step 10h.1): prune worktrees after each wave, warn about orphaned worktree directories
5. **Agent worktree constraints** in `SKILL.md`: explicit rules prohibiting `git worktree add`, nested worktrees, creating worktree directories, and modifying settings files
6. **Settings file protection** in `SKILL.md`: hard stop if an agent detects it is about to write `.claude/settings.local.json`

## Test plan

- [ ] Run a swarm with multiple waves and verify pre-wave checks execute before agent dispatch
- [ ] Confirm agents are dispatched with `isolation: "worktree"`
- [ ] Simulate a failed agent and verify post-agent cleanup removes the worktree and orphaned branch
- [ ] Verify post-wave cleanup prunes worktrees and reports orphaned directories
- [ ] Confirm feature agents do not create rogue `.claude/settings.local.json` files
- [ ] Confirm feature agents do not run `git worktree add`

🤖 Generated with [Claude Code](https://claude.com/claude-code)